### PR TITLE
Adding Peapod comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,16 @@
 			<artifactId>frames</artifactId>
 			<version>2.6.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.tinkerpop</groupId>
+			<artifactId>tinkergraph-gremlin</artifactId>
+			<version>3.0.0.M9-incubating</version>
+		</dependency>
+		<dependency>
+			<groupId>org.bayofmany.peapod</groupId>
+			<artifactId>peapod</artifactId>
+			<version>0.2.1-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>package</defaultGoal>
@@ -117,8 +127,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 		<dependency>
 			<groupId>org.bayofmany.peapod</groupId>
 			<artifactId>peapod</artifactId>
-			<version>0.2.1-SNAPSHOT</version>
+			<version>0.2.1</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/com/syncleus/ferma/benchmark/GodGraph3Loader.java
+++ b/src/main/java/com/syncleus/ferma/benchmark/GodGraph3Loader.java
@@ -1,0 +1,91 @@
+/******************************************************************************
+ * *
+ * Copyright: (c) Syncleus, Inc.                                              *
+ * *
+ * You may redistribute and modify this source code under the terms and       *
+ * conditions of the Open Source Community License - Type C version 1.0       *
+ * or any later version as published by Syncleus, Inc. at www.syncleus.com.   *
+ * There should be a copy of the license included with this file. If a copy   *
+ * of the license is not included you are granted no right to distribute or   *
+ * otherwise use this file except through a legal and valid license. You      *
+ * should also contact Syncleus, Inc. at the information below if you cannot  *
+ * find a license:                                                            *
+ * *
+ * Syncleus, Inc.                                                             *
+ * 2604 South 12th Street                                                     *
+ * Philadelphia, PA 19148                                                     *
+ * *
+ ******************************************************************************/
+package com.syncleus.ferma.benchmark;
+
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+
+
+/**
+ * Example Graph factory that creates a graph based on roman mythology.
+ */
+public class GodGraph3Loader {
+
+    public static void load(final TinkerGraph graph) {
+
+        // vertices
+        graph.createIndex("name", Vertex.class);
+
+        Vertex saturn = graph.addVertex(T.label, "god", "name", "saturn", "age", 10000, "type", "titan", "implementation_type", FermaGod.class.getName());
+
+        Vertex sky = graph.addVertex(T.label, "god", "name", "sky", "type", "location", "other", "more useless info");
+
+        Vertex sea = graph.addVertex(T.label, "god", "name", "sea", "type", "location");
+
+        Vertex jupiter = graph.addVertex(T.label, "god", "name", "jupiter", "age", 5000, "type", "god", "implementation_type", FermaGod.class.getName());
+
+        Vertex neptune = graph.addVertex(T.label, "god", "name", "neptune", "age", 4500, "type", "god", "implementation_type", FermaGod.class.getName());
+
+        Vertex hercules = graph.addVertex(T.label, "god", "name", "hercules", "age", 30, "type", "demigod", "implementation_type", FermaGodExtended.class.getName());
+
+        Vertex alcmene = graph.addVertex(T.label, "god", "name", "alcmene", "age", 45, "type", "human", "implementation_type", FermaGod.class.getName());
+
+        Vertex pluto = graph.addVertex(T.label, "god", "name", "pluto", "age", 4000, "type", "god", "implementation_type", FermaGod.class.getName());
+
+        Vertex nemean = graph.addVertex(T.label, "god", "name", "nemean", "type", "monster", "implementation_type", FermaGod.class.getName());
+
+        Vertex hydra = graph.addVertex(T.label, "god", "name", "hydra", "type", "monster", "implementation_type", FermaGod.class.getName());
+
+        Vertex cerberus = graph.addVertex(T.label, "god", "name", "cerberus", "type", "monster", "implementation_type", FermaGod.class.getName());
+
+        Vertex tartarus = graph.addVertex(T.label, "god", "name", "tartarus", "type", "location", "implementation_type", FermaGod.class.getName());
+
+        // edges
+
+        jupiter.addEdge("father", saturn, "implementation_type", FatherEdge.class.getName());
+        jupiter.addEdge("lives", sky, "reason", "loves fresh breezes");
+        jupiter.addEdge("brother", neptune);
+        jupiter.addEdge("brother", pluto);
+
+        neptune.addEdge("father", saturn, "implementation_type", FatherEdge.class.getName());
+        neptune.addEdge("lives", sea, "reason", "loves waves");
+        neptune.addEdge("brother", jupiter);
+        neptune.addEdge("brother", pluto);
+
+        hercules.addEdge("father", jupiter, "implementation_type", FatherEdgeExtended.class.getName());
+        hercules.addEdge("lives", sky, "reason", "loves heights");
+        hercules.addEdge("battled", nemean, "time", 1);
+        hercules.addEdge("battled", hydra, "time", 2);
+        hercules.addEdge("battled", cerberus, "time", 12);
+
+        pluto.addEdge("father", saturn, "implementation_type", FatherEdge.class.getName());
+        pluto.addEdge("brother", jupiter);
+        pluto.addEdge("brother", neptune);
+        pluto.addEdge("lives", tartarus, "reason", "no fear of death");
+        pluto.addEdge("pet", cerberus);
+
+        cerberus.addEdge("lives", tartarus);
+        cerberus.addEdge("battled", alcmene, "time", 5);
+
+        // commit the transaction to disk
+        if (graph.features().graph().supportsTransactions())
+            graph.tx().commit();
+    }
+}

--- a/src/main/java/com/syncleus/ferma/benchmark/GodGraphLoader.java
+++ b/src/main/java/com/syncleus/ferma/benchmark/GodGraphLoader.java
@@ -1,27 +1,26 @@
 /******************************************************************************
- *                                                                             *
- *  Copyright: (c) Syncleus, Inc.                                              *
- *                                                                             *
- *  You may redistribute and modify this source code under the terms and       *
- *  conditions of the Open Source Community License - Type C version 1.0       *
- *  or any later version as published by Syncleus, Inc. at www.syncleus.com.   *
- *  There should be a copy of the license included with this file. If a copy   *
- *  of the license is not included you are granted no right to distribute or   *
- *  otherwise use this file except through a legal and valid license. You      *
- *  should also contact Syncleus, Inc. at the information below if you cannot  *
- *  find a license:                                                            *
- *                                                                             *
- *  Syncleus, Inc.                                                             *
- *  2604 South 12th Street                                                     *
- *  Philadelphia, PA 19148                                                     *
- *                                                                             *
+ * *
+ * Copyright: (c) Syncleus, Inc.                                              *
+ * *
+ * You may redistribute and modify this source code under the terms and       *
+ * conditions of the Open Source Community License - Type C version 1.0       *
+ * or any later version as published by Syncleus, Inc. at www.syncleus.com.   *
+ * There should be a copy of the license included with this file. If a copy   *
+ * of the license is not included you are granted no right to distribute or   *
+ * otherwise use this file except through a legal and valid license. You      *
+ * should also contact Syncleus, Inc. at the information below if you cannot  *
+ * find a license:                                                            *
+ * *
+ * Syncleus, Inc.                                                             *
+ * 2604 South 12th Street                                                     *
+ * Philadelphia, PA 19148                                                     *
+ * *
  ******************************************************************************/
 package com.syncleus.ferma.benchmark;
 
 import com.tinkerpop.blueprints.KeyIndexableGraph;
 import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.blueprints.Vertex;
-import com.tinkerpop.blueprints.impls.tg.TinkerGraph;
 import com.tinkerpop.blueprints.util.ElementHelper;
 
 
@@ -29,11 +28,12 @@ import com.tinkerpop.blueprints.util.ElementHelper;
  * Example Graph factory that creates a graph based on roman mythology.
  */
 public class GodGraphLoader {
+
     public static void load(final KeyIndexableGraph graph) {
 
         // vertices
-    	graph.createKeyIndex("name", Vertex.class);
-    	
+        graph.createKeyIndex("name", Vertex.class);
+
         Vertex saturn = graph.addVertex(null);
         saturn.setProperty("name", "saturn");
         saturn.setProperty("age", 10000);
@@ -101,7 +101,7 @@ public class GodGraphLoader {
         ElementHelper.setProperties(cerberus.addEdge("battled", alcmene), "time", 5);
 
         // commit the transaction to disk
-        if( graph instanceof TransactionalGraph )
-            ((TransactionalGraph)graph).commit();
+        if (graph instanceof TransactionalGraph)
+            ((TransactionalGraph) graph).commit();
     }
 }

--- a/src/main/java/com/syncleus/ferma/benchmark/PeapodGod.java
+++ b/src/main/java/com/syncleus/ferma/benchmark/PeapodGod.java
@@ -1,0 +1,53 @@
+/******************************************************************************
+ *                                                                             *
+ *  Copyright: (c) Syncleus, Inc.                                              *
+ *                                                                             *
+ *  You may redistribute and modify this source code under the terms and       *
+ *  conditions of the Open Source Community License - Type C version 1.0       *
+ *  or any later version as published by Syncleus, Inc. at www.syncleus.com.   *
+ *  There should be a copy of the license included with this file. If a copy   *
+ *  of the license is not included you are granted no right to distribute or   *
+ *  otherwise use this file except through a legal and valid license. You      *
+ *  should also contact Syncleus, Inc. at the information below if you cannot  *
+ *  find a license:                                                            *
+ *                                                                             *
+ *  Syncleus, Inc.                                                             *
+ *  2604 South 12th Street                                                     *
+ *  Philadelphia, PA 19148                                                     *
+ *                                                                             *
+ ******************************************************************************/
+package com.syncleus.ferma.benchmark;
+
+import com.syncleus.ferma.ClassInitializer;
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.frames.Adjacency;
+import com.tinkerpop.frames.Property;
+import com.tinkerpop.frames.VertexFrame;
+import peapod.annotations.Edge;
+import peapod.annotations.In;
+import peapod.annotations.Out;
+import peapod.annotations.Vertex;
+
+import java.util.List;
+
+@Vertex("god")
+public abstract class PeapodGod {
+    abstract String getName();
+
+    abstract void setName(String newName);
+
+    abstract void removeName();
+
+    abstract Integer getAge();
+
+    abstract String getType();
+
+    @In
+    @Edge("father")
+    abstract List<PeapodGod> getSons();
+
+    @Out
+    @Edge("father")
+    abstract  List<PeapodGod>  getParents();
+
+}

--- a/src/test/java/com/syncleus/ferma/benchmark/PerformanceTest.java
+++ b/src/test/java/com/syncleus/ferma/benchmark/PerformanceTest.java
@@ -1,44 +1,52 @@
 /******************************************************************************
- *                                                                             *
- *  Copyright: (c) Syncleus, Inc.                                              *
- *                                                                             *
- *  You may redistribute and modify this source code under the terms and       *
- *  conditions of the Open Source Community License - Type C version 1.0       *
- *  or any later version as published by Syncleus, Inc. at www.syncleus.com.   *
- *  There should be a copy of the license included with this file. If a copy   *
- *  of the license is not included you are granted no right to distribute or   *
- *  otherwise use this file except through a legal and valid license. You      *
- *  should also contact Syncleus, Inc. at the information below if you cannot  *
- *  find a license:                                                            *
- *                                                                             *
- *  Syncleus, Inc.                                                             *
- *  2604 South 12th Street                                                     *
- *  Philadelphia, PA 19148                                                     *
- *                                                                             *
+ * *
+ * Copyright: (c) Syncleus, Inc.                                              *
+ * *
+ * You may redistribute and modify this source code under the terms and       *
+ * conditions of the Open Source Community License - Type C version 1.0       *
+ * or any later version as published by Syncleus, Inc. at www.syncleus.com.   *
+ * There should be a copy of the license included with this file. If a copy   *
+ * of the license is not included you are granted no right to distribute or   *
+ * otherwise use this file except through a legal and valid license. You      *
+ * should also contact Syncleus, Inc. at the information below if you cannot  *
+ * find a license:                                                            *
+ * *
+ * Syncleus, Inc.                                                             *
+ * 2604 South 12th Street                                                     *
+ * Philadelphia, PA 19148                                                     *
+ * *
  ******************************************************************************/
 package com.syncleus.ferma.benchmark;
 
-import com.codahale.metrics.*;
+import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.blueprints.impls.tg.TinkerGraph;
-import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import peapod.FramedGraphTraversal;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.List;
 
 public class PerformanceTest {
-    private static final Set<Class<?>> TEST_TYPES = new HashSet<Class<?>>(Arrays.asList(new Class<?>[]{FermaGod.class, FatherEdge.class, FermaGodExtended.class, FermaGodAlternative.class}));
+
+    private static final int ITERATIONS = 2_000_00;
+
     private static final MetricRegistry METRICS;
-    private static final com.codahale.metrics.Timer FERMA_TIMER;
-    private static final com.codahale.metrics.Timer TOTOROM_TIMER;
-    private static final com.codahale.metrics.Timer FRAMES_TIMER;
-    private static final com.codahale.metrics.Timer BLUEPRINTS_TIMER;
-    private static final com.codahale.metrics.Timer TINKERPOP3_TIMER;
-    private static final com.codahale.metrics.Timer GREMLIN_TIMER;
-    private static final com.codahale.metrics.Timer PEAPOD_TIMER;
+    private static final Timer FERMA_TIMER;
+    private static final Timer TOTOROM_TIMER;
+    private static final Timer FRAMES_TIMER;
+    private static final Timer BLUEPRINTS_TIMER;
+    private static final Timer TINKERPOP3_TIMER;
+    private static final Timer GREMLIN_TIMER;
+    private static final Timer PEAPOD_TIMER;
+
+    private static TinkerGraph godGraph;
+
+    private static org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph godGraph3;
 
     static {
         METRICS = new MetricRegistry();
@@ -51,19 +59,25 @@ public class PerformanceTest {
         PEAPOD_TIMER = METRICS.timer("peapod");
     }
 
-    @Test
-    public void testGetFramedVerticiesTyped() {
-        final int iterations = 2500000;
-
-        final TinkerGraph godGraph = new TinkerGraph();
+    @BeforeClass
+    public static void initAndWarmup() {
+        godGraph = new TinkerGraph();
         GodGraphLoader.load(godGraph);
 
-        final org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph godGraph3 = TinkerFactory.createClassic();
+        godGraph3 = org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph.open();
         GodGraph3Loader.load(godGraph3);
 
+        for (int i = 0; i < ITERATIONS; i++) {
+            Assert.assertNotNull(godGraph.getVertices("name", "saturn").iterator().next());
+            Assert.assertNotNull(godGraph3.traversal().V().has("name", "saturn").next());
+        }
+    }
+
+    @Test
+    public void testGetFramedVerticesTyped() {
         //Blueprints test
         com.codahale.metrics.Timer.Context time = BLUEPRINTS_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<Vertex> gods = godGraph.getVertices("name", "saturn");
             Iterator<Vertex> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -72,15 +86,16 @@ public class PerformanceTest {
 
         //Tinkerpop 3 test
         time = TINKERPOP3_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
-            Assert.assertTrue(godGraph3.traversal().V().has("name", "saturn").hasNext());
+        for (int i = 0; i < ITERATIONS; i++) {
+            GraphTraversal<org.apache.tinkerpop.gremlin.structure.Vertex, org.apache.tinkerpop.gremlin.structure.Vertex> it = godGraph3.traversal().V().hasLabel("god").has("name", "saturn");
+            Assert.assertTrue(it.hasNext());
         }
         final long tinkerpop3Elapsed = time.stop();
 
         //Ferma test
-        final com.syncleus.ferma.FramedGraph fermaGraph = new com.syncleus.ferma.DelegatingFramedGraph(godGraph, true, false);
+        final com.syncleus.ferma.FramedGraph fermaGraph = new com.syncleus.ferma.DelegatingFramedGraph<Graph>(godGraph, true, false);
         time = FERMA_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             final Iterable<? extends ConcreteFermaGod> gods = fermaGraph.getFramedVertices("name", "saturn", ConcreteFermaGod.class);
             Iterator<? extends ConcreteFermaGod> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -89,18 +104,19 @@ public class PerformanceTest {
 
         final org.jglue.totorom.FramedGraph totoromGraph = new org.jglue.totorom.FramedGraph(godGraph, org.jglue.totorom.FrameFactory.Default, org.jglue.totorom.TypeResolver.Java);
         time = TOTOROM_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<TotoromGod> gods = totoromGraph.V().has("name", "saturn").frame(TotoromGod.class);
             Iterator<TotoromGod> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
         }
         final long totoromElapsed = time.stop();
 
+        System.gc();
 
         com.tinkerpop.frames.FramedGraphFactory factory = new com.tinkerpop.frames.FramedGraphFactory(new com.tinkerpop.frames.modules.gremlingroovy.GremlinGroovyModule());
-        final com.tinkerpop.frames.FramedGraph framesGraph = factory.create(godGraph);
+        final com.tinkerpop.frames.FramedGraph<Graph> framesGraph = factory.create(godGraph);
         time = FRAMES_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<FramesGod> gods = framesGraph.getVertices("name", "saturn", FramesGod.class);
             Iterator<FramesGod> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -110,7 +126,7 @@ public class PerformanceTest {
 
         //Blueprints test
         time = GREMLIN_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<Vertex> gods = new com.tinkerpop.gremlin.java.GremlinPipeline<>(godGraph).V("name", "saturn");
             Iterator<Vertex> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -119,32 +135,27 @@ public class PerformanceTest {
 
         final peapod.FramedGraph peapodGraph = new peapod.FramedGraph(godGraph3, PeapodGod.class.getPackage());
         time = PEAPOD_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Assert.assertTrue(peapodGraph.V(PeapodGod.class).has("name", "saturn").hasNext());
         }
         final long peapodElapsed = time.stop();
 
 
         System.out.println();
-        System.out.println("=== testGetFramedVerticiesTyped ===");
-        System.out.println("blueprints comparison: " + ((double)blueprintsElapsed) / ((double)fermaElapsed) * 100.0 + "%");
-        System.out.println("tinkerpop3 comparison: " + ((double) tinkerpop3Elapsed) / ((double)fermaElapsed) * 100.0 + "%");
-        System.out.println("totorom comparison: " + ((double)totoromElapsed) / ((double)fermaElapsed) * 100.0 + "%");
-        System.out.println("frames comparison: " + ((double)framesElapsed) / ((double)fermaElapsed) * 100.0 + "%");
-        System.out.println("gremlin comparison: " + ((double)gremlinElapsed) / ((double)fermaElapsed) * 100.0 + "%");
-        System.out.println("peapod comparison: " +((double) peapodElapsed) /((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("=== testGetFramedVerticesTyped ===");
+        System.out.println("blueprints comparison: " + ((double) blueprintsElapsed) / ((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("tinkerpop3 comparison: " + ((double) tinkerpop3Elapsed) / ((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("totorom comparison: " + ((double) totoromElapsed) / ((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("frames comparison: " + ((double) framesElapsed) / ((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("gremlin comparison: " + ((double) gremlinElapsed) / ((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("peapod comparison: " + ((double) peapodElapsed) / ((double) fermaElapsed) * 100.0 + "%");
     }
 
     @Test
-    public void testGetFramedVerticiesUntyped() {
-        final int iterations = 2500000;
-
-        final TinkerGraph godGraph = new TinkerGraph();
-        GodGraphLoader.load(godGraph);
-
+    public void testGetFramedVerticesUntyped() {
         //Blueprints test
         com.codahale.metrics.Timer.Context time = BLUEPRINTS_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<Vertex> gods = godGraph.getVertices("name", "saturn");
             Iterator<Vertex> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -152,9 +163,9 @@ public class PerformanceTest {
         final long blueprintsElapsed = time.stop();
 
         //Ferma test
-        final com.syncleus.ferma.FramedGraph fermaGraph = new com.syncleus.ferma.DelegatingFramedGraph(godGraph, false, false);
+        final com.syncleus.ferma.FramedGraph fermaGraph = new com.syncleus.ferma.DelegatingFramedGraph<Graph>(godGraph, false, false);
         time = FERMA_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             final Iterable<? extends ConcreteFermaGod> gods = fermaGraph.getFramedVertices("name", "saturn", ConcreteFermaGod.class);
             Iterator<? extends ConcreteFermaGod> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -163,7 +174,7 @@ public class PerformanceTest {
 
         final org.jglue.totorom.FramedGraph totoromGraph = new org.jglue.totorom.FramedGraph(godGraph, org.jglue.totorom.FrameFactory.Default, org.jglue.totorom.TypeResolver.Untyped);
         time = TOTOROM_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<TotoromGod> gods = totoromGraph.V().has("name", "saturn").frame(TotoromGod.class);
             Iterator<TotoromGod> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -172,7 +183,7 @@ public class PerformanceTest {
 
         //Gremlin test
         time = GREMLIN_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<Vertex> gods = new com.tinkerpop.gremlin.java.GremlinPipeline<>(godGraph).V("name", "saturn");
             Iterator<Vertex> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -181,26 +192,18 @@ public class PerformanceTest {
 
 
         System.out.println();
-        System.out.println("=== testGetFramedVerticiesUntyped ===");
-        System.out.println("blueprints comparison: " + ((double)blueprintsElapsed) / ((double)fermaElapsed) * 100.0 + "%");
-        System.out.println("totorom comparison: " + ((double)totoromElapsed) / ((double)fermaElapsed) * 100.0 + "%");
+        System.out.println("=== testGetFramedVerticesUntyped ===");
+        System.out.println("blueprints comparison: " + ((double) blueprintsElapsed) / ((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("totorom comparison: " + ((double) totoromElapsed) / ((double) fermaElapsed) * 100.0 + "%");
         System.out.println("frames comparison: Not capable");
-        System.out.println("gremlin comparison: " + ((double)gremlinElapsed) / ((double)fermaElapsed) * 100.0 + "%");
+        System.out.println("gremlin comparison: " + ((double) gremlinElapsed) / ((double) fermaElapsed) * 100.0 + "%");
     }
 
     @Test
-    public void testGetFramedVerticiesAndNextTyped() {
-        final int iterations = 1000000;
-
-        final TinkerGraph godGraph = new TinkerGraph();
-        GodGraphLoader.load(godGraph);
-
-        final org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph godGraph3 = TinkerFactory.createClassic();
-        GodGraph3Loader.load(godGraph3);
-
+    public void testGetFramedVerticesAndNextTyped() {
         //Blueprints test
         com.codahale.metrics.Timer.Context time = BLUEPRINTS_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<Vertex> gods = godGraph.getVertices("name", "saturn");
             Iterator<Vertex> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -211,7 +214,7 @@ public class PerformanceTest {
 
         //Tinkerpop 3 test
         time = TINKERPOP3_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterator<org.apache.tinkerpop.gremlin.structure.Vertex> it = godGraph3.traversal().V().has("name", "saturn");
             Assert.assertTrue(it.hasNext());
             it.next();
@@ -219,9 +222,9 @@ public class PerformanceTest {
         final long tinkerpop3Elapsed = time.stop();
 
         //Ferma test
-        final com.syncleus.ferma.FramedGraph fermaGraph = new com.syncleus.ferma.DelegatingFramedGraph(godGraph, true, false);
+        final com.syncleus.ferma.FramedGraph fermaGraph = new com.syncleus.ferma.DelegatingFramedGraph<Graph>(godGraph, true, false);
         time = FERMA_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             final Iterable<? extends ConcreteFermaGod> gods = fermaGraph.getFramedVertices("name", "saturn", ConcreteFermaGod.class);
             Iterator<? extends ConcreteFermaGod> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -232,7 +235,7 @@ public class PerformanceTest {
 
         final org.jglue.totorom.FramedGraph totoromGraph = new org.jglue.totorom.FramedGraph(godGraph, org.jglue.totorom.FrameFactory.Default, org.jglue.totorom.TypeResolver.Java);
         time = TOTOROM_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<TotoromGod> gods = totoromGraph.V().has("name", "saturn").frame(TotoromGod.class);
             Iterator<TotoromGod> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -243,9 +246,9 @@ public class PerformanceTest {
 
 
         com.tinkerpop.frames.FramedGraphFactory factory = new com.tinkerpop.frames.FramedGraphFactory(new com.tinkerpop.frames.modules.gremlingroovy.GremlinGroovyModule());
-        final com.tinkerpop.frames.FramedGraph framesGraph = factory.create(godGraph);
+        final com.tinkerpop.frames.FramedGraph<Graph> framesGraph = factory.create(godGraph);
         time = FRAMES_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<FramesGod> gods = framesGraph.getVertices("name", "saturn", FramesGod.class);
             Iterator<FramesGod> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -256,7 +259,7 @@ public class PerformanceTest {
 
         //Gremlin test
         time = GREMLIN_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<Vertex> gods = new com.tinkerpop.gremlin.java.GremlinPipeline<>(godGraph).V("name", "saturn");
             Iterator<Vertex> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -267,7 +270,7 @@ public class PerformanceTest {
 
         final peapod.FramedGraph peapodGraph = new peapod.FramedGraph(godGraph3, PeapodGod.class.getPackage());
         time = PEAPOD_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterator<PeapodGod> it = peapodGraph.V(PeapodGod.class).has("name", "saturn");
             Assert.assertTrue(it.hasNext());
             it.next();
@@ -275,25 +278,20 @@ public class PerformanceTest {
         final long peapodElapsed = time.stop();
 
         System.out.println();
-        System.out.println("=== testGetFramedVerticiesAndNextTyped ===");
-        System.out.println("blueprints comparison: " + ((double)blueprintsElapsed) / ((double)fermaElapsed) * 100.0 + "%");
-        System.out.println("tinkerpop3 comparison: " +((double) tinkerpop3Elapsed) /((double) fermaElapsed) * 100.0 + "%");
-        System.out.println("totorom comparison: " + ((double)totoromElapsed) / ((double)fermaElapsed) * 100.0 + "%");
-        System.out.println("frames comparison: " + ((double)framesElapsed) / ((double)fermaElapsed) * 100.0 + "%");
-        System.out.println("gremlin comparison: " + ((double)gremlinElapsed) / ((double)fermaElapsed) * 100.0 + "%");
-        System.out.println("peapod comparison: " +((double) peapodElapsed) /((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("=== testGetFramedVerticesAndNextTyped ===");
+        System.out.println("blueprints comparison: " + ((double) blueprintsElapsed) / ((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("tinkerpop3 comparison: " + ((double) tinkerpop3Elapsed) / ((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("totorom comparison: " + ((double) totoromElapsed) / ((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("frames comparison: " + ((double) framesElapsed) / ((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("gremlin comparison: " + ((double) gremlinElapsed) / ((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("peapod comparison: " + ((double) peapodElapsed) / ((double) fermaElapsed) * 100.0 + "%");
     }
 
     @Test
-    public void testGetFramedVerticiesAndNextUntyped() {
-        final int iterations = 5000000;
-
-        final TinkerGraph godGraph = new TinkerGraph();
-        GodGraphLoader.load(godGraph);
-
+    public void testGetFramedVerticesAndNextUntyped() {
         //Blueprints test
         com.codahale.metrics.Timer.Context time = BLUEPRINTS_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<Vertex> gods = godGraph.getVertices("name", "saturn");
             Iterator<Vertex> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -303,9 +301,9 @@ public class PerformanceTest {
         final long blueprintsElapsed = time.stop();
 
         //Ferma test
-        final com.syncleus.ferma.FramedGraph fermaGraph = new com.syncleus.ferma.DelegatingFramedGraph(godGraph, false, false);
+        final com.syncleus.ferma.FramedGraph fermaGraph = new com.syncleus.ferma.DelegatingFramedGraph<Graph>(godGraph, false, false);
         time = FERMA_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             final Iterable<? extends ConcreteFermaGod> gods = fermaGraph.getFramedVertices("name", "saturn", ConcreteFermaGod.class);
             Iterator<? extends ConcreteFermaGod> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -316,7 +314,7 @@ public class PerformanceTest {
 
         final org.jglue.totorom.FramedGraph totoromGraph = new org.jglue.totorom.FramedGraph(godGraph, org.jglue.totorom.FrameFactory.Default, org.jglue.totorom.TypeResolver.Untyped);
         time = TOTOROM_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<TotoromGod> gods = totoromGraph.V().has("name", "saturn").frame(TotoromGod.class);
             Iterator<TotoromGod> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -327,7 +325,7 @@ public class PerformanceTest {
 
         //Gremlin test
         time = GREMLIN_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<Vertex> gods = new com.tinkerpop.gremlin.java.GremlinPipeline<>(godGraph).V("name", "saturn");
             Iterator<Vertex> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
@@ -337,50 +335,42 @@ public class PerformanceTest {
         final long gremlinElapsed = time.stop();
 
         System.out.println();
-        System.out.println("=== testGetFramedVerticiesAndNextUntyped ===");
-        System.out.println("blueprints comparison: " + ((double)blueprintsElapsed) / ((double)fermaElapsed) * 100.0 + "%");
-        System.out.println("totorom comparison: " + ((double)totoromElapsed) / ((double)fermaElapsed) * 100.0 + "%");
+        System.out.println("=== testGetFramedVerticesAndNextUntyped ===");
+        System.out.println("blueprints comparison: " + ((double) blueprintsElapsed) / ((double) fermaElapsed) * 100.0 + "%");
+        System.out.println("totorom comparison: " + ((double) totoromElapsed) / ((double) fermaElapsed) * 100.0 + "%");
         System.out.println("frames comparison: Not capable");
-        System.out.println("gremlin comparison: " + ((double)gremlinElapsed) / ((double)fermaElapsed) * 100.0 + "%");
+        System.out.println("gremlin comparison: " + ((double) gremlinElapsed) / ((double) fermaElapsed) * 100.0 + "%");
     }
 
     @Test
     public void testGetAnnotatedAdjacencies() {
-        final int iterations = 250000;
-
-        final TinkerGraph godGraph = new TinkerGraph();
-        GodGraphLoader.load(godGraph);
-
-        final org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph godGraph3 = TinkerFactory.createClassic();
-        GodGraph3Loader.load(godGraph3);
-
         //Ferma test
-        final com.syncleus.ferma.FramedGraph fermaGraph = new com.syncleus.ferma.DelegatingFramedGraph(godGraph, true, true);
+        final com.syncleus.ferma.FramedGraph fermaGraph = new com.syncleus.ferma.DelegatingFramedGraph<Graph>(godGraph, true, true);
         Timer.Context time = FERMA_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             final Iterable<? extends FermaGod> gods = fermaGraph.getFramedVertices("name", "saturn", FermaGod.class);
             Iterator<? extends FermaGod> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
 
             final FermaGod father = godsIterator.next();
             Iterable<? extends FermaGod> children = father.getSons(FermaGod.class);
-            for(final FermaGod child : children)
+            for (final FermaGod child : children)
                 Assert.assertTrue(child.getParents().iterator().next().getName().equals("saturn"));
         }
         final long fermaElapsed = time.stop();
 
         //Frames test
         com.tinkerpop.frames.FramedGraphFactory factory = new com.tinkerpop.frames.FramedGraphFactory(new com.tinkerpop.frames.modules.gremlingroovy.GremlinGroovyModule());
-        final com.tinkerpop.frames.FramedGraph framesGraph = factory.create(godGraph);
+        final com.tinkerpop.frames.FramedGraph<Graph> framesGraph = factory.create(godGraph);
         time = FRAMES_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterable<FramesGod> gods = framesGraph.getVertices("name", "saturn", FramesGod.class);
             Iterator<FramesGod> godsIterator = gods.iterator();
             Assert.assertTrue(godsIterator.hasNext());
 
             final FramesGod father = godsIterator.next();
             Iterable<? extends FramesGod> children = father.getSons();
-            for(final FramesGod child : children)
+            for (final FramesGod child : children)
                 Assert.assertTrue(child.getParents().iterator().next().getName().equals("saturn"));
         }
         final long framesElapsed = time.stop();
@@ -388,13 +378,13 @@ public class PerformanceTest {
         //Peapod test
         final peapod.FramedGraph peapodGraph = new peapod.FramedGraph(godGraph3, PeapodGod.class.getPackage());
         time = PEAPOD_TIMER.time();
-        for(int i = 0; i < iterations; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             Iterator<PeapodGod> it = peapodGraph.V(PeapodGod.class).has("name", "saturn");
             Assert.assertTrue(it.hasNext());
 
             final PeapodGod father = it.next();
             List<PeapodGod> children = father.getSons();
-            for(final PeapodGod child : children)
+            for (final PeapodGod child : children)
                 Assert.assertTrue(child.getParents().iterator().next().getName().equals("saturn"));
 
         }
@@ -404,8 +394,8 @@ public class PerformanceTest {
         System.out.println("=== testGetAnnotatedAdjacencies ===");
         System.out.println("blueprints comparison: Not capable");
         System.out.println("totorom comparison: Not capable");
-        System.out.println("frames comparison: " + ((double)framesElapsed) / ((double)fermaElapsed) * 100.0 + "%");
+        System.out.println("frames comparison: " + ((double) framesElapsed) / ((double) fermaElapsed) * 100.0 + "%");
         System.out.println("gremlin comparison: Not capable");
-        System.out.println("peapod comparison: " + ((double)peapodElapsed) / ((double)fermaElapsed) * 100.0 + "%");
+        System.out.println("peapod comparison: " + ((double) peapodElapsed) / ((double) fermaElapsed) * 100.0 + "%");
     }
 }

--- a/src/test/java/com/syncleus/ferma/benchmark/PerformanceTest.java
+++ b/src/test/java/com/syncleus/ferma/benchmark/PerformanceTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 public class PerformanceTest {
 
-    private static final int ITERATIONS = 2_000_00;
+    private static final int ITERATIONS = 2_000_000;
 
     private static final MetricRegistry METRICS;
     private static final Timer FERMA_TIMER;

--- a/src/test/java/com/syncleus/ferma/benchmark/PerformanceTest.java
+++ b/src/test/java/com/syncleus/ferma/benchmark/PerformanceTest.java
@@ -269,7 +269,7 @@ public class PerformanceTest {
         time = PEAPOD_TIMER.time();
         for(int i = 0; i < iterations; i++) {
             Iterator<PeapodGod> it = peapodGraph.V(PeapodGod.class).has("name", "saturn");
-           // Assert.assertTrue(it.hasNext()); TODO
+            Assert.assertTrue(it.hasNext());
             it.next();
         }
         final long peapodElapsed = time.stop();


### PR DESCRIPTION
Hi,

I added Peapod to the comparison. At this moment it supports: JPA-like Annotations, Type information encoded into graph, Framing of elements instantiated according to type hierarchy, Element queried by type hierarchy & TinkerPop 3.

Performance is still behind, but mainly due to TinkerPop 3 being less performant then version 2 and using a lot more objects to GC. I'm sure it will improve in next versions.

I added a warmup cycle for the base frameworks Blueprint & TinkerPop3 because I saw several runs where they performed slower then the OGM frameworks using them.

Thanks for updating your comparison.

Willem
